### PR TITLE
Add simple FastAPI demucs server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# music_breakdown
+# Music Breakdown
+
+This project provides a small FastAPI application that accepts an audio file and separates it into six stems: vocals, drums, guitar, piano, bass, and other instruments. The separation is done using the [Demucs](https://github.com/facebookresearch/demucs) library's 6-stem model.
+
+## Setup
+
+Install the required packages (preferably inside a virtual environment):
+
+```bash
+pip install -r requirements.txt
+```
+
+Demucs will download pretrained weights on first run, so internet access is required for that step.
+
+## Running the server
+
+```bash
+uvicorn app.main:app --reload
+```
+
+Then open `http://localhost:8000` in your browser to upload an audio file. The separated stems will be returned as a zip archive.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,45 @@
+import os
+import shutil
+import subprocess
+import uuid
+from fastapi import FastAPI, UploadFile, File
+from fastapi.responses import FileResponse
+from fastapi.templating import Jinja2Templates
+from fastapi import Request
+
+app = FastAPI()
+templates = Jinja2Templates(directory="app/templates")
+
+OUTPUT_DIR = "outputs"
+os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+@app.get("/")
+def index(request: Request):
+    return templates.TemplateResponse("index.html", {"request": request})
+
+@app.post("/separate")
+async def separate(file: UploadFile = File(...)):
+    file_id = str(uuid.uuid4())
+    input_path = os.path.join(OUTPUT_DIR, f"{file_id}_{file.filename}")
+    with open(input_path, "wb") as f:
+        content = await file.read()
+        f.write(content)
+
+    stem_out = os.path.join(OUTPUT_DIR, file_id)
+    os.makedirs(stem_out, exist_ok=True)
+
+    # Use demucs 6-stem model for separation
+    command = [
+        "python3", "-m", "demucs.separate",
+        "--model", "htdemucs_6s",
+        "--out", stem_out,
+        input_path
+    ]
+    try:
+        subprocess.run(command, check=True)
+    except Exception as e:
+        return {"error": str(e)}
+
+    # Compress results for download
+    archive_path = shutil.make_archive(stem_out, 'zip', stem_out)
+    return FileResponse(archive_path, filename=f"{file.filename}_stems.zip")

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Music Breakdown</title>
+</head>
+<body>
+    <h1>Upload Audio File</h1>
+    <form action="/separate" method="post" enctype="multipart/form-data">
+        <input type="file" name="file" accept="audio/*" required>
+        <button type="submit">Separate</button>
+    </form>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn
+jinja2
+spleeter
+python-multipart
+demucs


### PR DESCRIPTION
## Summary
- document setup and usage for a music separation app
- provide FastAPI server with demucs 6-stem separation
- add minimal HTML upload page
- specify app dependencies

## Testing
- `python3 -m py_compile app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6841b5a0768c8322930eb0bb07daf244